### PR TITLE
fix: Pokemon search correctly displays Pokemon

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,28 +103,24 @@ function assessPokemonTypeQuantity(typeQuantity) {
 
 $lowerNextButton.addEventListener("click", () => {
   if (nextPokemonList === null) return function () {};
-  // Maybe we can add an alert that says that they are at the begining or the end
   deletePreviousPokemonCards();
   loadPokemonList(nextPokemonList);
 });
 
 $upperNextButton.addEventListener("click", () => {
   if (nextPokemonList === null) return function () {};
-  // Maybe we can add an alert that says that they are at the begining or the end
   deletePreviousPokemonCards();
   loadPokemonList(nextPokemonList);
 });
 
 $lowerPreviousButton.addEventListener("click", () => {
   if (previousPokemonList === null) return function () {};
-  // Maybe we can add an alert that says that they are at the begining or the end
   deletePreviousPokemonCards();
   loadPokemonList(previousPokemonList);
 });
 
 $upperPreviousButton.addEventListener("click", () => {
   if (previousPokemonList === null) return function () {};
-  // Maybe we can add an alert that says that they are at the begining or the end
   deletePreviousPokemonCards();
   loadPokemonList(previousPokemonList);
 });
@@ -155,10 +151,18 @@ function validateForm(event) {
 }
 
 function validateSearchBar(pokemon) {
-  const regEx = /^[A-z]+$/;
+  const regEx = /^[a-z]+$/i;
+  const regEx2 = /^[a-z]+-[a-z]+$/i;
+  const regEx3 = /^[a-z]+-[a-z]+-[a-z]+$/i;
 
-  if (!regEx.test(pokemon)) return "The Pokemon name has invalid characters.";
-  if (pokemon.length >= 12) return "The Pokemon name is too long.";
+  if (!regEx.test(pokemon)) {
+    if (!regEx2.test(pokemon)) {
+      if (!regEx3.test(pokemon)) {
+        return "The Pokemon name has invalid characters.";
+      }
+    }
+  }
+  if (pokemon.length >= 30) return "The Pokemon name is too long.";
 
   return "";
 }

--- a/src/unitary-tests.js
+++ b/src/unitary-tests.js
@@ -1,13 +1,14 @@
 function testValidateSearchBar() {
   console.assert(
-    validateSearchBar("p1k4chu") === "The Pokemon name has invalid characters.",
+    validateSearchBar("p1k4chu-!") ===
+      "The Pokemon name has invalid characters.",
     "The function validateSearchBar did not validate if the input value had invalid characters."
   );
 
   console.assert(
-    validateSearchBar("pikachupikachupikachu") ===
+    validateSearchBar("pikachupikachupikachupikachupikachupikachu") ===
       "The Pokemon name is too long.",
-    "The function validateSearcBar did not validate if the input value was too long."
+    "The function validateSearchBar did not validate if the input value was too long."
   );
 }
 


### PR DESCRIPTION
The Pokemon search wasnt displaying pokemons that had longer names like 'Urshifu-single-strike' because the Regular Expression wasn't allowing the search of that kinds of string. Now it does. It also accepts now longer string lengths up to 30 characters